### PR TITLE
added gem for faster windows dev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,9 @@ group :development, :test do
 
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console', '~> 2.0'
+
+  gem 'rails-dev-boost', :git => 'git://github.com/thedarkone/rails-dev-boost.git' # may help speed up dev on windows
+  gem 'wdm', '>= 0.0.3'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: git://github.com/thedarkone/rails-dev-boost.git
+  revision: 15ebc37b3f1b424ce7f5a160d2a8f890023208e6
+  specs:
+    rails-dev-boost (0.3.0)
+      railties (>= 3.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -38,6 +45,7 @@ GEM
       tzinfo (~> 1.1)
     arel (6.0.0)
     bcrypt (3.1.10-x64-mingw32)
+    bcrypt (3.1.10-x86-mingw32)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
@@ -86,6 +94,8 @@ GEM
     minitest (5.5.1)
     multi_json (1.11.0)
     nokogiri (1.6.6.2-x64-mingw32)
+      mini_portile (~> 0.6.0)
+    nokogiri (1.6.6.2-x86-mingw32)
       mini_portile (~> 0.6.0)
     orm_adapter (0.5.0)
     paperclip (4.2.1)
@@ -148,6 +158,7 @@ GEM
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
     sqlite3 (1.3.10-x64-mingw32)
+    sqlite3 (1.3.10-x86-mingw32)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
@@ -167,6 +178,7 @@ GEM
       json (>= 1.8.0)
     warden (1.2.3)
       rack (>= 1.0)
+    wdm (0.1.0)
     web-console (2.1.2)
       activemodel (>= 4.0)
       binding_of_caller (>= 0.7.2)
@@ -175,6 +187,7 @@ GEM
 
 PLATFORMS
   x64-mingw32
+  x86-mingw32
 
 DEPENDENCIES
   byebug
@@ -184,6 +197,7 @@ DEPENDENCIES
   jquery-rails
   paperclip (~> 4.2.1)
   rails (= 4.2.1)
+  rails-dev-boost!
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   simple_form (~> 3.1.0)
@@ -192,4 +206,5 @@ DEPENDENCIES
   twitter-bootstrap-rails (~> 3.2.0)
   tzinfo-data
   uglifier (>= 1.3.0)
+  wdm (>= 0.0.3)
   web-console (~> 2.0)


### PR DESCRIPTION
I was going to introduce a less hack-ish way to implement the toggle activation feature (by just reusing the conventional update route), but it seems you found an alternative to the problem. anyhow, these gems are nice for windows dev.
